### PR TITLE
One header from RFC 4229

### DIFF
--- a/specs/src/rfc4229.xml
+++ b/specs/src/rfc4229.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- The initial HTTP Header registry. -->
+<service primary="IETF" secondary="RFC" id="4229">
+    <title>HTTP Header Field Registrations</title>
+    <documentation source="https://tools.ietf.org/html/rfc4229">HTTP/1.0 and HTTP/1.1 define protocol constructs (respectively, the HTTP-header and message-header BNF rules) that are used as message headers.  These specifications also define a number of HTTP headers themselves, and they provide for extension through the use of new field-names. This document defines the initial contents of an IANA registry that catalogs permanent HTTP header field-names, and of an IANA repository that catalogs provisional HTTP header field-names.  Both are operated according to Registration Procedures for Message Header Fields.</documentation>
+    <http-header def="Title">
+        <documentation source="https://tools.ietf.org/html/rfc4229#section-2.2.11">The title of the document. Not part of the document. Isomorphic with the &lt;title&gt; element in HTML.</documentation>
+    </http-header>
+</service>

--- a/specs/src/rfc4229.xml
+++ b/specs/src/rfc4229.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- The initial HTTP Header registry. -->
 <service primary="IETF" secondary="RFC" id="4229">
     <title>HTTP Header Field Registrations</title>
-    <documentation source="https://tools.ietf.org/html/rfc4229">HTTP/1.0 and HTTP/1.1 define protocol constructs (respectively, the HTTP-header and message-header BNF rules) that are used as message headers.  These specifications also define a number of HTTP headers themselves, and they provide for extension through the use of new field-names. This document defines the initial contents of an IANA registry that catalogs permanent HTTP header field-names, and of an IANA repository that catalogs provisional HTTP header field-names.  Both are operated according to Registration Procedures for Message Header Fields.</documentation>
+    <documentation source="http://tools.ietf.org/html/rfc4229">This document defines the initial contents of a permanent IANA registry for HTTP header fields and a provisional repository for HTTP header fields</documentation>
     <http-header def="Title">
-        <documentation source="https://tools.ietf.org/html/rfc4229#section-2.2.11">The title of the document. Not part of the document. Isomorphic with the &lt;title&gt; element in HTML.</documentation>
+        <documentation source="http://tools.ietf.org/html/rfc4229#section-2.2.11">The title of the document. Not part of the document. Isomorphic with the &lt;title&gt; element in HTML.</documentation>
     </http-header>
 </service>


### PR DESCRIPTION
The Title header field is sometimes useful to carry information.  The RFC doesn't explicitly define what the title field does, it only references a document by @timbl back in 1994, and I grandfathered in the text from there. Is this right @dret?

Probably there are more headers in RFC 4229 that should be added, but one would have to subtract the things that are defined elsewhere.  What happens if there are two claims to define a single web concept?
